### PR TITLE
fix: stabilize projects mobile layout and add skills nav

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -35,7 +35,7 @@ export default function ProjectsPage() {
         variants={staggerChildren(0.08)}
         className="pt-8 md:pt-12"
       >
-        <motion.div variants={fadeInUp()} className="space-y-7 md:space-y-8">
+        <motion.div variants={fadeInUp({ reducedMotion: true })} className="space-y-7 md:space-y-8">
           <div className="layout-header space-y-4">
             <p className="ui-eyebrow text-accent/90">制作一覧</p>
             <h1 className="ui-page-title layout-title-page text-foreground md:text-[clamp(2.3rem,4.2vw,4.35rem)]">
@@ -47,7 +47,7 @@ export default function ProjectsPage() {
           </div>
 
           <motion.div
-            variants={fadeIn()}
+            variants={fadeIn(0, true)}
             className="rounded-[1.6rem] border border-line/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.94),rgba(245,248,253,0.86))] p-3 shadow-[0_14px_34px_rgba(27,44,74,0.06)] md:p-4"
           >
             <div className="flex flex-col gap-4">
@@ -130,7 +130,7 @@ export default function ProjectsPage() {
           </motion.div>
 
           <motion.div
-            variants={fadeIn()}
+            variants={fadeIn(0, true)}
             className="layout-reading-wide rounded-[1.45rem] border border-line/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.9),rgba(246,249,253,0.82))] px-5 py-4 shadow-[0_10px_26px_rgba(27,44,74,0.05)]"
           >
             <p className="text-[11px] font-semibold tracking-[0.08em] text-muted-foreground">一覧の見方</p>
@@ -144,8 +144,7 @@ export default function ProjectsPage() {
       <motion.section
         className="pt-9 md:pt-12"
         initial="initial"
-        whileInView="animate"
-        viewport={defaultViewport}
+        animate="animate"
         variants={staggerChildren(0.06)}
       >
         <div className="mb-5 flex flex-col gap-2.5 sm:flex-row sm:items-end sm:justify-between">
@@ -172,8 +171,7 @@ export default function ProjectsPage() {
               {visibleFeaturedWorks.map((work, index) => (
                 <motion.article
                   key={`${activeFilter}-${work.title}`}
-                  variants={fadeInUp({ delay: index * 0.02, distance: 16 })}
-                  layout
+                  variants={fadeInUp({ delay: index * 0.02, distance: 16, reducedMotion: true })}
                 >
                   <WorkCard {...work} />
                 </motion.article>
@@ -194,8 +192,7 @@ export default function ProjectsPage() {
               {visibleAllWorks.map((work, index) => (
                 <motion.article
                   key={`${activeFilter}-${work.title}`}
-                  variants={fadeInUp({ delay: index * 0.02, distance: 12 })}
-                  layout
+                  variants={fadeInUp({ delay: index * 0.02, distance: 12, reducedMotion: true })}
                 >
                   <CompactWorkCard project={work} />
                 </motion.article>
@@ -205,7 +202,7 @@ export default function ProjectsPage() {
         ) : null}
 
         {visibleWorksCount === 0 ? (
-          <motion.div variants={fadeInUp()} className="pt-6">
+          <motion.div variants={fadeInUp({ reducedMotion: true })} className="pt-6">
             <Card
               interactive={false}
               inset
@@ -227,7 +224,7 @@ export default function ProjectsPage() {
         initial="initial"
         whileInView="animate"
         viewport={defaultViewport}
-        variants={fadeInUp()}
+        variants={fadeInUp({ reducedMotion: true })}
       >
         <Card
           interactive={false}

--- a/src/components/layout/site-header.tsx
+++ b/src/components/layout/site-header.tsx
@@ -13,6 +13,7 @@ const navItems = [
   { href: "/", label: "ホーム" },
   { href: "/projects", label: "制作物" },
   { href: "/about", label: "プロフィール" },
+  { href: "/skills", label: "スキル" },
   { href: "/contact", label: "連絡先" },
 ];
 


### PR DESCRIPTION
This pull request focuses on improving motion accessibility and navigation in the `ProjectsPage` and site header. The main updates include adding reduced motion support to animation variants for better accessibility and introducing a new navigation link for "スキル" (Skills).

**Accessibility improvements (reduced motion support):**
* Updated all uses of `fadeInUp` and `fadeIn` animation variants in `ProjectsPage` to include the `reducedMotion: true` option, ensuring smoother experience for users with motion sensitivity. This affects project listings, empty state, and other animated sections. [[1]](diffhunk://#diff-77154bf8a7b0126e79f2818a349df89aaaffda07cf88710602c844958985b12fL38-R38) [[2]](diffhunk://#diff-77154bf8a7b0126e79f2818a349df89aaaffda07cf88710602c844958985b12fL175-R174) [[3]](diffhunk://#diff-77154bf8a7b0126e79f2818a349df89aaaffda07cf88710602c844958985b12fL197-R195) [[4]](diffhunk://#diff-77154bf8a7b0126e79f2818a349df89aaaffda07cf88710602c844958985b12fL208-R205) [[5]](diffhunk://#diff-77154bf8a7b0126e79f2818a349df89aaaffda07cf88710602c844958985b12fL230-R227)
* Updated `fadeIn` animation variants to use explicit parameters for delay and reduced motion where appropriate. [[1]](diffhunk://#diff-77154bf8a7b0126e79f2818a349df89aaaffda07cf88710602c844958985b12fL50-R50) [[2]](diffhunk://#diff-77154bf8a7b0126e79f2818a349df89aaaffda07cf88710602c844958985b12fL133-R133)

**Navigation update:**
* Added a new navigation item for `/skills` ("スキル") in the site header, making the skills page accessible from the main navigation.

**Animation trigger fix:**
* Changed the `motion.section` animation trigger from `whileInView` to `animate` for more predictable animation behavior.