### PR TITLE
Fix final release visual blockers

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -80,11 +80,11 @@ export default function AboutPage() {
       <motion.section
         initial="initial"
         animate="animate"
-        variants={staggerChildren(0.08)}
+        variants={staggerChildren({ gap: 0.08, reducedMotion: true })}
         className="pt-8 md:pt-12"
       >
         <div className="grid gap-5 xl:grid-cols-[minmax(0,1.08fr)_minmax(20rem,0.92fr)] xl:gap-6">
-          <motion.div variants={fadeInUp()}>
+          <motion.div variants={fadeInUp({ reducedMotion: true })}>
             <Card
               interactive={false}
               inset
@@ -150,7 +150,7 @@ export default function AboutPage() {
             </Card>
           </motion.div>
 
-          <motion.div variants={fadeInUp()}>
+          <motion.div variants={fadeInUp({ reducedMotion: true })}>
             <Card
               interactive={false}
               padding="none"
@@ -199,10 +199,10 @@ export default function AboutPage() {
         initial="initial"
         whileInView="animate"
         viewport={defaultViewport}
-        variants={staggerChildren(0.08)}
+        variants={staggerChildren({ gap: 0.08, reducedMotion: true })}
       >
         <motion.div
-          variants={fadeIn()}
+          variants={fadeIn(0, true)}
           className="mx-auto flex max-w-3xl flex-wrap items-center justify-center gap-3.5"
         >
           {timelineItems.map((item) => (
@@ -216,11 +216,11 @@ export default function AboutPage() {
         </motion.div>
 
         <motion.div
-          variants={staggerChildren(0.08)}
+          variants={staggerChildren({ gap: 0.08, reducedMotion: true })}
           className="mt-8 grid gap-5 md:mt-10 md:grid-cols-2 md:items-stretch xl:grid-cols-3"
         >
           {storyBlocks.map((block) => (
-            <motion.div key={block.index} variants={fadeInUp()}>
+            <motion.div key={block.index} variants={fadeInUp({ reducedMotion: true })}>
               <Card
                 interactive={false}
                 inset
@@ -257,10 +257,10 @@ export default function AboutPage() {
         initial="initial"
         whileInView="animate"
         viewport={defaultViewport}
-        variants={staggerChildren(0.08)}
+        variants={staggerChildren({ gap: 0.08, reducedMotion: true })}
         aria-labelledby="journey-heading"
       >
-        <motion.div variants={fadeInUp()} className="mb-7 space-y-3 md:mb-9">
+        <motion.div variants={fadeInUp({ reducedMotion: true })} className="mb-7 space-y-3 md:mb-9">
           <p className="ui-eyebrow text-muted-foreground">Journey</p>
           <h2
             id="journey-heading"
@@ -273,7 +273,7 @@ export default function AboutPage() {
           </p>
         </motion.div>
 
-        <motion.div variants={fadeInUp()}>
+        <motion.div variants={fadeInUp({ reducedMotion: true })}>
           <Card
             interactive={false}
             inset

--- a/src/components/layout/site-header.test.tsx
+++ b/src/components/layout/site-header.test.tsx
@@ -33,6 +33,18 @@ describe("SiteHeader", () => {
     expect(currentLinks).toHaveLength(2);
   });
 
+  it("keeps project navigation active for nested project routes", async () => {
+    mockedUsePathname.mockReturnValue("/projects/wincook");
+
+    render(<SiteHeader />);
+
+    await userEvent.click(screen.getByRole("button", { name: "メニュー" }));
+
+    const currentLinks = screen.getAllByRole("link", { name: "制作物", current: "page" });
+    expect(currentLinks).toHaveLength(2);
+    expect(screen.queryByRole("link", { name: "プロフィール", current: "page" })).not.toBeInTheDocument();
+  });
+
   it("opens and closes the mobile menu from user actions", async () => {
     render(<SiteHeader />);
 

--- a/src/components/layout/site-header.tsx
+++ b/src/components/layout/site-header.tsx
@@ -17,6 +17,24 @@ const navItems = [
   { href: "/contact", label: "連絡先" },
 ];
 
+function normalizePathname(pathname: string | null) {
+  if (!pathname || pathname === "/") {
+    return "/";
+  }
+
+  return pathname.replace(/\/+$/, "");
+}
+
+function isNavItemActive(pathname: string | null, href: string) {
+  const currentPath = normalizePathname(pathname);
+
+  if (href === "/") {
+    return currentPath === "/";
+  }
+
+  return currentPath === href || currentPath.startsWith(`${href}/`);
+}
+
 export function SiteHeader() {
   const pathname = usePathname();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -46,21 +64,25 @@ export function SiteHeader() {
             </span>
           </InternalLink>
           <nav className="hidden items-center gap-1 md:flex">
-            {navItems.map((item) => (
-              <InternalLink
-                key={item.href}
-                href={item.href}
-                className={cn(
-                  "rounded-pill px-4 py-2 text-sm tracking-[0.01em] transition-[background-color,color,border-color,box-shadow] duration-200",
-                  pathname === item.href
-                    ? "bg-background text-foreground shadow-[0_8px_18px_rgba(0,0,0,0.07)]"
-                    : "text-muted-foreground hover:bg-background/92 hover:text-foreground"
-                )}
-                aria-current={pathname === item.href ? "page" : undefined}
-              >
-                {item.label}
-              </InternalLink>
-            ))}
+            {navItems.map((item) => {
+              const isActive = isNavItemActive(pathname, item.href);
+
+              return (
+                <InternalLink
+                  key={item.href}
+                  href={item.href}
+                  className={cn(
+                    "rounded-pill px-4 py-2 text-sm tracking-[0.01em] transition-[background-color,color,border-color,box-shadow] duration-200",
+                    isActive
+                      ? "bg-background text-foreground shadow-[0_8px_18px_rgba(0,0,0,0.07)]"
+                      : "text-muted-foreground hover:bg-background/92 hover:text-foreground"
+                  )}
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  {item.label}
+                </InternalLink>
+              );
+            })}
           </nav>
           <div className="relative shrink-0 md:hidden">
             <motion.button
@@ -91,22 +113,26 @@ export function SiteHeader() {
                 isMenuOpen ? "block" : "hidden"
               )}
             >
-              {navItems.map((item) => (
-                <InternalLink
-                  key={item.href}
-                  href={item.href}
-                  className={cn(
-                    "block rounded-[0.9rem] px-3 py-2.5 text-sm tracking-[0.01em] transition-[background-color,color,box-shadow] duration-200",
-                    pathname === item.href
-                      ? "bg-background text-foreground shadow-[0_8px_18px_rgba(0,0,0,0.06)]"
-                      : "text-foreground/84 hover:bg-background hover:text-foreground"
-                  )}
-                  aria-current={pathname === item.href ? "page" : undefined}
-                  onClick={() => setIsMenuOpen(false)}
-                >
-                  {item.label}
-                </InternalLink>
-              ))}
+              {navItems.map((item) => {
+                const isActive = isNavItemActive(pathname, item.href);
+
+                return (
+                  <InternalLink
+                    key={item.href}
+                    href={item.href}
+                    className={cn(
+                      "block rounded-[0.9rem] px-3 py-2.5 text-sm tracking-[0.01em] transition-[background-color,color,box-shadow] duration-200",
+                      isActive
+                        ? "bg-background text-foreground shadow-[0_8px_18px_rgba(0,0,0,0.06)]"
+                        : "text-foreground/84 hover:bg-background hover:text-foreground"
+                    )}
+                    aria-current={isActive ? "page" : undefined}
+                    onClick={() => setIsMenuOpen(false)}
+                  >
+                    {item.label}
+                  </InternalLink>
+                );
+              })}
             </nav>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Fixed the /about visual blank state
- Fixed stale navigation active state during client-side navigation
- Preserved the monochrome premium UI direction

## Verification
- npm run typecheck
- npm run test
- npm run build
- Checked /, /about, /projects, /skills, /contact
- Verified navigation active state updates correctly

## Notes
- No project data changes
- No new dependencies
- No new routes
- No merge performed